### PR TITLE
TDPrimeTest as singleton.

### DIFF
--- a/src/de/tilman_neumann/jml/factor/base/PrimeBaseGenerator.java
+++ b/src/de/tilman_neumann/jml/factor/base/PrimeBaseGenerator.java
@@ -34,7 +34,7 @@ public class PrimeBaseGenerator {
 	private static final Logger LOG = Logger.getLogger(PrimeBaseGenerator.class);
 	private static final boolean DEBUG = false;
 	
-	private AutoExpandingPrimesArray rawPrimesArray = AutoExpandingPrimesArray.get();
+	private AutoExpandingPrimesArray rawPrimesArray = AutoExpandingPrimesArray.getInstance();
 	private JacobiSymbol jacobiEngine = new JacobiSymbol();
 
 	/**

--- a/src/de/tilman_neumann/jml/factor/cfrac/KnuthSchroeppel_CFrac.java
+++ b/src/de/tilman_neumann/jml/factor/cfrac/KnuthSchroeppel_CFrac.java
@@ -41,7 +41,7 @@ public class KnuthSchroeppel_CFrac {
 	private static final double FOUR_BY_3 = 4.0/3.0 * Math.log(2);
 
 	// 10000 primes would always be enough, but using the expandable sieve is nicer
-	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.get();
+	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.getInstance();
 	private SquarefreeSequence squareFreeSequence = new SquarefreeSequence(1);
 
 	private int[] kArray = new int[10000];

--- a/src/de/tilman_neumann/jml/factor/ecm/EllipticCurveMethod.java
+++ b/src/de/tilman_neumann/jml/factor/ecm/EllipticCurveMethod.java
@@ -110,7 +110,7 @@ public class EllipticCurveMethod extends FactorAlgorithm {
 			BigNbr1[i] = 0;
 		}
 		
-		final AutoExpandingPrimesArray autoPrimes = AutoExpandingPrimesArray.get().ensureLimit(5000);
+		final AutoExpandingPrimesArray autoPrimes = AutoExpandingPrimesArray.getInstance().ensureLimit(5000);
 		SmallPrime[0] = 2;
 		for (int indexM = 1; indexM < SmallPrime.length; indexM++) {
 			SmallPrime[indexM] = autoPrimes.getPrime(indexM);

--- a/src/de/tilman_neumann/jml/factor/hart/HartLA63.java
+++ b/src/de/tilman_neumann/jml/factor/hart/HartLA63.java
@@ -44,7 +44,7 @@ public class HartLA63 extends FactorAlgorithm {
 	private static final Logger LOG = Logger.getLogger(HartLA63.class);
 	private static final boolean DEBUG = false;
 
-	private final AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();
+	private final AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();
 
 	// input
 	private BigInteger N, kN;

--- a/src/de/tilman_neumann/jml/factor/hart/Hart_TDiv_Race.java
+++ b/src/de/tilman_neumann/jml/factor/hart/Hart_TDiv_Race.java
@@ -52,7 +52,7 @@ public class Hart_TDiv_Race extends FactorAlgorithm {
 	private int[] primes;
 	private double[] reciprocals;
 	
-	private final AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();
+	private final AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();
 	private final Gcd63 gcdEngine = new Gcd63();
 
 	/**

--- a/src/de/tilman_neumann/jml/factor/hart/Hart_TDiv_Race2.java
+++ b/src/de/tilman_neumann/jml/factor/hart/Hart_TDiv_Race2.java
@@ -52,7 +52,7 @@ public class Hart_TDiv_Race2 extends FactorAlgorithm {
 	private int[] primes;
 	private double[] reciprocals;
 	
-	private final AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();
+	private final AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();
 	private final Gcd63 gcdEngine = new Gcd63();
 
 	/**

--- a/src/de/tilman_neumann/jml/factor/lehman/Lehman_AnalyzeSpecialArguments.java
+++ b/src/de/tilman_neumann/jml/factor/lehman/Lehman_AnalyzeSpecialArguments.java
@@ -32,7 +32,7 @@ import de.tilman_neumann.jml.factor.FactorAlgorithm;
 public class Lehman_AnalyzeSpecialArguments extends FactorAlgorithm {
 	private static final Logger LOG = Logger.getLogger(Lehman_AnalyzeSpecialArguments.class);
 	
-	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get().ensurePrimeCount(NUM_PRIMES_FOR_31_BIT_TDIV);
+	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance().ensurePrimeCount(NUM_PRIMES_FOR_31_BIT_TDIV);
 
 	private final Gcd63 gcdEngine = new Gcd63();
 

--- a/src/de/tilman_neumann/jml/factor/siqs/KnuthSchroeppel.java
+++ b/src/de/tilman_neumann/jml/factor/siqs/KnuthSchroeppel.java
@@ -51,7 +51,7 @@ public class KnuthSchroeppel {
 	private static final double PENALTY_WEIGHT = 0.35;
 
 	// 10000 primes would always be enough, but using the auto-expanding sieve facade is nicer
-	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.get();
+	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.getInstance();
 	private SquarefreeSequence63 squareFreeSequence = new SquarefreeSequence63(1);
 
 	private int[] kArray = new int[10000];

--- a/src/de/tilman_neumann/jml/factor/tdiv/TDiv.java
+++ b/src/de/tilman_neumann/jml/factor/tdiv/TDiv.java
@@ -30,7 +30,7 @@ public class TDiv {
 	@SuppressWarnings("unused")
 	private static final Logger LOG = Logger.getLogger(TDiv.class);
 	
-	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();
+	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();
 
 	/**
 	 * Tries to find small factors of a positive, possibly large argument N by doing trial division

--- a/src/de/tilman_neumann/jml/factor/tdiv/TDiv31.java
+++ b/src/de/tilman_neumann/jml/factor/tdiv/TDiv31.java
@@ -27,7 +27,7 @@ import de.tilman_neumann.util.SortedMultiset_BottomUp;
  */
 public class TDiv31 extends FactorAlgorithm {
 
-	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get().ensurePrimeCount(NUM_PRIMES_FOR_31_BIT_TDIV);
+	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance().ensurePrimeCount(NUM_PRIMES_FOR_31_BIT_TDIV);
 
 	@Override
 	public String getName() {

--- a/src/de/tilman_neumann/jml/factor/tdiv/TDiv31Barrett.java
+++ b/src/de/tilman_neumann/jml/factor/tdiv/TDiv31Barrett.java
@@ -34,7 +34,7 @@ public class TDiv31Barrett extends FactorAlgorithm {
 	@SuppressWarnings("unused")
 	private static final Logger LOG = Logger.getLogger(TDiv31Barrett.class);
 
-	private AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();	// "static" would be slightly slower
+	private AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();	// "static" would be slightly slower
 
 	private int[] primes;
 	private long[] pinv;

--- a/src/de/tilman_neumann/jml/factor/tdiv/TDiv31Inverse.java
+++ b/src/de/tilman_neumann/jml/factor/tdiv/TDiv31Inverse.java
@@ -36,7 +36,7 @@ import de.tilman_neumann.util.SortedMultiset_BottomUp;
  */
 public class TDiv31Inverse extends FactorAlgorithm {
 	
-	private AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();	// "static" would be slightly slower
+	private AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();	// "static" would be slightly slower
 
 	// The allowed discriminator bit size is d <= 53 - bitLength(N/p), thus d<=23 would be safe
 	// for any integer N and p>=2. d=10 is the value that performs best, determined by experiment.

--- a/src/de/tilman_neumann/jml/factor/tdiv/TDiv63.java
+++ b/src/de/tilman_neumann/jml/factor/tdiv/TDiv63.java
@@ -27,7 +27,7 @@ import de.tilman_neumann.util.SortedMultiset_BottomUp;
  */
 public class TDiv63 extends FactorAlgorithm {
 	
-	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get().ensurePrimeCount(NUM_PRIMES_FOR_31_BIT_TDIV);
+	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance().ensurePrimeCount(NUM_PRIMES_FOR_31_BIT_TDIV);
 
 	private int pLimit = Integer.MAX_VALUE;
 

--- a/src/de/tilman_neumann/jml/factor/tdiv/TDiv63Inverse.java
+++ b/src/de/tilman_neumann/jml/factor/tdiv/TDiv63Inverse.java
@@ -44,7 +44,7 @@ import de.tilman_neumann.util.SortedMultiset_BottomUp;
 public class TDiv63Inverse extends FactorAlgorithm {
 	private static final Logger LOG = Logger.getLogger(TDiv63Inverse.class);
 	
-	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();
+	private static AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();
 
 	private static final int DISCRIMINATOR_BITS = 10; // experimental result
 	private static final double DISCRIMINATOR = 1.0/(1<<DISCRIMINATOR_BITS);

--- a/src/de/tilman_neumann/jml/powers/PurePowerTest.java
+++ b/src/de/tilman_neumann/jml/powers/PurePowerTest.java
@@ -46,7 +46,7 @@ public class PurePowerTest {
 	private static final double LN_3 = Math.log(3);
 	
 	private Gcd31 gcdEngine = new Gcd31();
-	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.get();
+	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.getInstance();
 
 	public static class Result {
 		public BigInteger base;

--- a/src/de/tilman_neumann/jml/primes/exact/AutoExpandingPrimesArray.java
+++ b/src/de/tilman_neumann/jml/primes/exact/AutoExpandingPrimesArray.java
@@ -40,7 +40,7 @@ public class AutoExpandingPrimesArray implements SieveCallback {
 	// singleton
 	private static final AutoExpandingPrimesArray THE_PRIMES_ARRAY = new AutoExpandingPrimesArray();
 	
-	public static AutoExpandingPrimesArray get() {
+	public static AutoExpandingPrimesArray getInstance() {
 		return THE_PRIMES_ARRAY;
 	}
 	

--- a/src/de/tilman_neumann/jml/primes/probable/BPSWTest.java
+++ b/src/de/tilman_neumann/jml/primes/probable/BPSWTest.java
@@ -39,7 +39,7 @@ public class BPSWTest {
 		return hashset;
 	}
 	
-	private TDivPrimeTest tdiv = new TDivPrimeTest();
+	private TDivPrimeTest tdiv;
 	private MillerRabinTest millerRabinTest = new MillerRabinTest();
 	private LucasTest lucasTest = new LucasTest();
 
@@ -53,6 +53,7 @@ public class BPSWTest {
 
         // For small N, trial division is much faster than BPSW
         if (N.bitLength() < 32) {
+        	tdiv = TDivPrimeTest.getInstance();
         	return tdiv.isPrime(N.intValue());
         }
         

--- a/src/de/tilman_neumann/jml/primes/probable/PrPTest.java
+++ b/src/de/tilman_neumann/jml/primes/probable/PrPTest.java
@@ -47,7 +47,7 @@ public class PrPTest {
 		return hashset;
 	}
 	
-	private TDivPrimeTest tdiv = new TDivPrimeTest();
+	private TDivPrimeTest tdiv;
 	private MillerRabinTest millerRabinTest = new MillerRabinTest();
 	private LucasTest lucasTest = new LucasTest();
 
@@ -61,7 +61,8 @@ public class PrPTest {
 
         // For small N, trial division is much faster than BPSW
         int Nbits = N.bitLength();
-        if (Nbits < 32) {
+		tdiv = TDivPrimeTest.getInstance();
+		if (Nbits < 32) {
         	return tdiv.isPrime(N.intValue());
         }
         

--- a/src/de/tilman_neumann/jml/primes/probable/TDivPrimeTest.java
+++ b/src/de/tilman_neumann/jml/primes/probable/TDivPrimeTest.java
@@ -29,12 +29,15 @@ public class TDivPrimeTest {
 	private static final int NUM_PRIMES_FOR_31_BIT_TDIV = 4793;
 
 	// TODO "static" leads to NPE in constructor ???
-	private AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.get();
+	private AutoExpandingPrimesArray SMALL_PRIMES = AutoExpandingPrimesArray.getInstance();
 
 	private int[] primes;
 	private long[] pinv;
-	
-	public TDivPrimeTest() {
+
+	private static TDivPrimeTest instance = new TDivPrimeTest();
+	public static TDivPrimeTest getInstance() { return instance; }
+
+	private TDivPrimeTest() {
 		primes = new int[NUM_PRIMES_FOR_31_BIT_TDIV];
 		pinv = new long[NUM_PRIMES_FOR_31_BIT_TDIV];
 		for (int i=0; i<NUM_PRIMES_FOR_31_BIT_TDIV; i++) {

--- a/src/de/tilman_neumann/jml/sequence/SquarefreeSequence.java
+++ b/src/de/tilman_neumann/jml/sequence/SquarefreeSequence.java
@@ -29,7 +29,7 @@ import de.tilman_neumann.util.ConfigUtil;
 public class SquarefreeSequence implements NumberSequence<BigInteger> {
 	private static final Logger LOG = Logger.getLogger(SquarefreeSequence.class);
 
-	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.get();
+	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.getInstance();
 	
 	private BigInteger multiplier;
 	private BigInteger next;

--- a/src/de/tilman_neumann/jml/sequence/SquarefreeSequence63.java
+++ b/src/de/tilman_neumann/jml/sequence/SquarefreeSequence63.java
@@ -25,7 +25,7 @@ import de.tilman_neumann.util.ConfigUtil;
 public class SquarefreeSequence63 implements NumberSequence<Long> {
 	private static final Logger LOG = Logger.getLogger(SquarefreeSequence63.class);
 
-	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.get();
+	private AutoExpandingPrimesArray primesArray = AutoExpandingPrimesArray.getInstance();
 	
 	private long multiplier;
 	private long next;


### PR DESCRIPTION
Use TDPrimeTest.getInstance() instead of new TDprimeTest()

PrPTest and BPSWTest for example avoid initialization when not needed